### PR TITLE
Added smoothing to racing drive based off of elevator height

### DIFF
--- a/src/org/usfirst/frc/team1360/robot/teleop/DriverConfig.java
+++ b/src/org/usfirst/frc/team1360/robot/teleop/DriverConfig.java
@@ -6,12 +6,15 @@ import org.usfirst.frc.team1360.robot.IO.RobotOutputProvider;
 import org.usfirst.frc.team1360.robot.IO.SensorInputProvider;
 import org.usfirst.frc.team1360.robot.util.OrbitPID;
 import org.usfirst.frc.team1360.robot.util.Singleton;
+import org.usfirst.frc.team1360.robot.util.log.LogProvider;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public enum DriverConfig {
 	RACING 
 	{
 		@Override
-		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput)
+		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput)
 		{
 			double speed = humanInput.getRacingThrottle();
 			double turn = humanInput.getRacingTurn();
@@ -23,6 +26,13 @@ public enum DriverConfig {
 				turn = turn / 2;
 			}
 			
+			double elevatorHeight = sensorInput.getElevatorEncoder();
+			log.write("Elevator Enc == " + elevatorHeight / 100);
+			double multiplier = Math.cos((1/33.165) * (elevatorHeight / 100));
+			log.write("Multiplier == " + multiplier);
+			
+			speed = speed * multiplier;
+			
 			robotOutput.arcadeDrive(speed, turn);
 			robotOutput.shiftGear(humanInput.getRacingShift());
 		}
@@ -31,7 +41,7 @@ public enum DriverConfig {
 	HALO 
 	{
 		@Override
-		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput)
+		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput)
 		{
 			double turn = humanInput.getHaloTurn();
 			
@@ -47,7 +57,7 @@ public enum DriverConfig {
 	{
 
 		@Override
-		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput)
+		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput)
 		{
 			double left = humanInput.getTankLeft();
 			double right = humanInput.getTankRight();
@@ -68,7 +78,7 @@ public enum DriverConfig {
 	{
 
 		@Override
-		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput) 
+		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput) 
 		{
 			double turn = humanInput.getArcadeTurn();
 			
@@ -84,7 +94,7 @@ public enum DriverConfig {
 	JOYSTICKTANK
 	{
 		@Override
-		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput)
+		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput)
 		{
 			
 			robotOutput.tankDrive(humanInput.getLeftJoystickThrottle(), humanInput.getRightJoystickThrottle());
@@ -97,7 +107,7 @@ public enum DriverConfig {
 	CHEESYDRIVE
 	{
 		@Override
-		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput)
+		public void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput)
 		{
 			robotOutput.cheesyDrive(humanInput.getCheesyThrottle(),
 					humanInput.getCheesyTurn(),
@@ -108,5 +118,6 @@ public enum DriverConfig {
 		
 	};
 	
-	public abstract void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput);
+	protected LogProvider log = Singleton.get(LogProvider.class);
+	public abstract void calculate(RobotOutputProvider robotOutput, HumanInputProvider humanInput, SensorInputProvider sensorInput);
 }

--- a/src/org/usfirst/frc/team1360/robot/teleop/TeleopDrive.java
+++ b/src/org/usfirst/frc/team1360/robot/teleop/TeleopDrive.java
@@ -2,6 +2,7 @@ package org.usfirst.frc.team1360.robot.teleop;
 
 import org.usfirst.frc.team1360.robot.IO.HumanInputProvider;
 import org.usfirst.frc.team1360.robot.IO.RobotOutputProvider;
+import org.usfirst.frc.team1360.robot.IO.SensorInputProvider;
 import org.usfirst.frc.team1360.robot.teleop.TeleopComponent;
 import org.usfirst.frc.team1360.robot.util.Singleton;
 
@@ -10,7 +11,7 @@ public class TeleopDrive implements TeleopComponent {
 	
 	public void calculate() 
 	{
-		cfg.calculate(Singleton.get(RobotOutputProvider.class), Singleton.get(HumanInputProvider.class));
+		cfg.calculate(Singleton.get(RobotOutputProvider.class), Singleton.get(HumanInputProvider.class), Singleton.get(SensorInputProvider.class));
 	}
 
 	public void disable() {


### PR DESCRIPTION
the smoothing function is f(x) = cos((1/33.165)x).  The 33.165 is the top height encoder limit (2211) divided by 2, multiplied by 3, and divided by 100.  This sets the max speed to just under 80% when the elevator is fully up.